### PR TITLE
Update core_crosshair.cfg

### DIFF
--- a/cfg/ultimateconfig/core/core_crosshair.cfg
+++ b/cfg/ultimateconfig/core/core_crosshair.cfg
@@ -64,14 +64,14 @@ cl_crosshair_alpha								255
 cl_crosshair_dynamic							0
 cl_crosshair_thickness							2
 
-alias "coff"									"cl_crosshair_alpha 0"
-alias "cdefault"								"cl_colorblind 1; cl_crosshair_alpha 255"
+alias "coff"                                    "crosshair 0; cl_crosshair_alpha 0" //# disable weapon and melee crosshair						
+alias "cdefault"								"crosshair_rebuild_default" "crosshair 1; cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_blue 220; cl_crosshair_green 182; cl_crosshair_red 138; cl_crosshair_dynamic 1; cl_crosshair_thickness 2" //# real default crosshair cvar =) https://developer.valvesoftware.com/wiki/List_of_Left_4_Dead_2_console_commands_and_variables
 alias "cblue"									"cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 0; cl_crosshair_green 0; cl_crosshair_blue 255"
 alias "ccyan"									"cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 0; cl_crosshair_green 255; cl_crosshair_blue 255"
 alias "cgreen"									"cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 0; cl_crosshair_green 255; cl_crosshair_blue 0"
 alias "corange"									"cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 255; cl_crosshair_green 128; cl_crosshair_blue 0"
 alias "cpurple"									"cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 255; cl_crosshair_green 0; cl_crosshair_blue 255"
-alias "cred"									"cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 255; cl_crosshair_green 0; cl_crosshair_blue 0"
+alias "cred"								    "cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 255; cl_crosshair_green 0; cl_crosshair_blue 0"
 alias "cwhite"									"cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 255; cl_crosshair_green 255; cl_crosshair_blue 255"
 alias "cyellow"									"cl_colorblind 0; cl_crosshair_alpha 255; cl_crosshair_red 255; cl_crosshair_green 255; cl_crosshair_blue 0"
 


### PR DESCRIPTION
Add real default crosshair (because cwhite exist) and melee weapon crosshair disable for using hudsight correctly